### PR TITLE
add log compaction

### DIFF
--- a/kvs_client.py
+++ b/kvs_client.py
@@ -24,6 +24,12 @@ def put(server, key, value):
     logger.debug(f'Return {response.status_code}: {response.text}')
     return response.status_code, response.text
 
+def compact_log(server):
+    logger.debug(f'{server}/compact_log')
+    response = requests.post(f'{server}/compact_log')
+    logger.debug(f'Return {response.status_code}: {response.text}')
+    return response.status_code, response.text
+
 def measure_once(servers, num_requests):
     server_id = random.choice(list(servers.keys()))
     keys = [random.randint(1, 10) for _ in range(num_requests)]
@@ -57,6 +63,17 @@ def measure_once(servers, num_requests):
         else:
             logger.error('Put failed')
     end_time = time.perf_counter()
+
+    # Compact log
+    status_code, text = compact_log(servers[server_id])
+    if status_code == 302:
+        server_id = int(text)
+        status_code, text = compact_log(servers[server_id])
+    if status_code != 200:
+        logger.error(
+            f'Unexpected failure: get({servers[server_id]}, {key}), ' \
+            f'code={status_code}, text={text}')
+
     return end_time - start_time
 
 if __name__ == '__main__':

--- a/kvs_cluster.py
+++ b/kvs_cluster.py
@@ -64,6 +64,18 @@ def setup_server(node_id):
         logger.info("Respond 200: ok")
         return web.Response(text="ok")
 
+    @routes.post('/compact_log')
+    async def compact_log(request: web.Request):
+        logger.info("/compact_log")
+        leader = get_node_id(raftos.get_leader())
+        if leader != node_id:
+            logger.info(f"Respond 302: {leader}")
+            return web.Response(status=302, text=str(leader))
+
+        await raftos.compact_log()
+        logger.info("Respond 200: ok")
+        return web.Response(text="ok")
+
     app = web.Application()
     app.add_routes(routes)
     return app.make_handler()

--- a/raftos/__init__.py
+++ b/raftos/__init__.py
@@ -15,9 +15,11 @@ __all__ = [
     'stop',
 
     'get_leader',
-    'wait_until_leader'
+    'wait_until_leader',
+    'compact_log'
 ]
 
 
 get_leader = State.get_leader
 wait_until_leader = State.wait_until_leader
+compact_log = State.compact_log

--- a/raftos/storage.py
+++ b/raftos/storage.py
@@ -61,6 +61,10 @@ class FileDict:
 
         return self.serializer.unpack(content)
 
+    def keys(self):
+        self.cache = self._get_file_content()
+        return self.cache.keys()
+
 
 class Log:
     """Persistent Raft Log on a disk
@@ -142,6 +146,14 @@ class Log:
         for entry in updated:
             self.write(entry['term'], entry['command'])
 
+    def reset(self):
+        open(self.filename, "wb").close()
+        self.cache = []
+        self.commit_index = 0
+        self.last_applied = 0
+        self.next_index = None
+        self.match_index = None
+
     @property
     def last_log_index(self):
         """Index of last log entry staring from _one_"""
@@ -167,6 +179,9 @@ class StateMachine(FileDict):
 
         self.update(command)
 
+    def reset(self):
+        open(self.filename, "wb").close()
+        self.cache = {}
 
 class FileStorage(FileDict):
     """Persistent storage

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -2,4 +2,4 @@
 
 python kvs_cluster.py --num_nodes 9 --benchmark &
 sleep 5
-python kvs_client.py --num_nodes 9 --num_requests 10000 --num_measurement 10 &
+python kvs_client.py --num_nodes 9 --num_requests 1000 --num_measurement 10 &


### PR DESCRIPTION
Closes #17.

This PR implements log compaction by adding an `install_snapshot` RPC and log cleaning, and exposes a `compact_log` interface to `raftos` module, which requires leadership to call.

When `compact_log` is called, the leader applies all uncommitted logs to its state machine, clear its log, and sends all the other servers its snapshot of state machine. Upon receiving the RPC, the follower nodes would clear their own log and accept the snapshot, realizing log compaction.

Reference evaluation:
```
[2023-11-24 13:05:38,144 kvs_client.py:101 INFO] Number of nodes: 9
[2023-11-24 13:05:38,144 kvs_client.py:102 INFO] Number of requests: 1000
[2023-11-24 13:05:38,144 kvs_client.py:103 INFO] Number of measurements: 10
[2023-11-24 13:05:38,144 kvs_client.py:104 INFO] Start measurement
[2023-11-24 13:05:44,279 kvs_client.py:113 INFO] Measurement 1: 163.067
[2023-11-24 13:05:50,281 kvs_client.py:113 INFO] Measurement 2: 166.726
[2023-11-24 13:05:56,138 kvs_client.py:113 INFO] Measurement 3: 170.837
[2023-11-24 13:06:02,274 kvs_client.py:113 INFO] Measurement 4: 163.100
[2023-11-24 13:06:08,328 kvs_client.py:113 INFO] Measurement 5: 165.312
[2023-11-24 13:06:14,351 kvs_client.py:113 INFO] Measurement 6: 166.140
[2023-11-24 13:06:20,097 kvs_client.py:113 INFO] Measurement 7: 174.149
[2023-11-24 13:06:26,216 kvs_client.py:113 INFO] Measurement 8: 163.542
[2023-11-24 13:06:32,383 kvs_client.py:113 INFO] Measurement 9: 162.246
[2023-11-24 13:06:38,298 kvs_client.py:113 INFO] Measurement 10: 169.192
[2023-11-24 13:06:38,298 kvs_client.py:116 INFO] Average TPS (transaction per second): 166.431
```

TPC doesn't degrade in later measurements since we're calling `compact_log` after each measurement.